### PR TITLE
docs: Fix a few typos

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -806,7 +806,7 @@ You can embed fragments of the target language into wax, similar to embedding as
 
 ### Datatype mapping
 
-wax tries to give the genrated code an "idomatic" look & feel by mapping wax types directly to common types in target language whenever possible, in favor of rolling out custom ones.
+wax tries to give the generated code an "idiomatic" look & feel by mapping wax types directly to common types in target language whenever possible, in favor of rolling out custom ones.
 
 |   | int | float | str | vec | arr | map |
 |---|-----|-------|-----|-----|-----|-----|

--- a/src/parser.c
+++ b/src/parser.c
@@ -127,7 +127,7 @@ const char* tokens_desc[] = {"","L-PAREN","R-PAREN","INT-LIT","FLT-LIT","STR-LIT
 #define EXPR_STRNEQ 606
 #define EXPR_STRCAT 607
 
-// funciton things
+// function things
 #define EXPR_FUNCBODY 651
 #define EXPR_FUNCHEAD 652
 


### PR DESCRIPTION
There are small typos in:
- QUICKSTART.md
- src/parser.c

Fixes:
- Should read `idiomatic` rather than `idomatic`.
- Should read `generated` rather than `genrated`.
- Should read `function` rather than `funciton`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md